### PR TITLE
Update documentation for smtp testing

### DIFF
--- a/content/smtp/testing.md
+++ b/content/smtp/testing.md
@@ -48,7 +48,7 @@ if (process.env.NODE_ENV === 'production' ){
         port: 587,
         auth: {
             user: 'real.user',
-            user: 'verysecret'
+            pass: 'verysecret'
         }
     };
 } else {
@@ -58,7 +58,7 @@ if (process.env.NODE_ENV === 'production' ){
         port: 587,
         auth: {
             user: 'ethereal.user@ethereal.email',
-            user: 'verysecret'
+            pass: 'verysecret'
         }
     };
 }


### PR DESCRIPTION
The config option `auth.user` appears twice in the documentation and I believe the second should be `auth.pass`.