### PR TITLE
Add default timeout timings to documentation for timeout options

### DIFF
--- a/content/smtp/index.md
+++ b/content/smtp/index.md
@@ -50,9 +50,9 @@ Setting **secure** to **false** does not mean that you would not use an encrypte
 
   - **name** – optional hostname of the client, used for identifying to the server, defaults to hostname of the machine
   - **localAddress** – is the local interface to bind to for network connections
-  - **connectionTimeout** – how many milliseconds to wait for the connection to establish
-  - **greetingTimeout** – how many milliseconds to wait for the greeting after connection is established
-  - **socketTimeout** – how many milliseconds of inactivity to allow
+  - **connectionTimeout** – how many milliseconds to wait for the connection to establish (default is 2 minutes)
+  - **greetingTimeout** – how many milliseconds to wait for the greeting after connection is established (default is 30 seconds)
+  - **socketTimeout** – how many milliseconds of inactivity to allow (default is 10 minutes)
 
 ##### Debug options
 


### PR DESCRIPTION
I'm unsure about how anyone would like these formatted, but I thought this would be useful information to list in the documentation.